### PR TITLE
use latest version of golangci-lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.45.2
+        version: latest
 
     - name: Coverage
       run: go test -v -race -cover ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,8 +13,8 @@ linters-settings:
     locale: US
   gci:
     sections:
-      - Std
-      - Def
+      - standard
+      - default
       - prefix(github.com/lovoo/protoc-gen-go-grpcmock)
 
 severity:
@@ -24,11 +24,14 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
     - bodyclose
-    - deadcode
+    - containedctx
+    - contextcheck
     - depguard
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
     - exhaustive
     - exportloopref
@@ -48,19 +51,29 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - interfacebloat
+    - makezero
     - misspell
     - nakedret
     - nestif
+    - nilerr
+    - nilnil
     - noctx
     - nolintlint
+    - nosprintfhostport
     - prealloc
+    - promlinter
+    - reassign
+    - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
+    - thelper
+    - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
+    - usestdlibvars
+    - wastedassign
     - whitespace

--- a/cmd/protoc-gen-go-grpcmock/main.go
+++ b/cmd/protoc-gen-go-grpcmock/main.go
@@ -1,14 +1,17 @@
 // protoc-gen-go-grpcmock is a plugin for the Google protocol buffer compiler to
 // generate Go code. Install it by building this program and making it
 // accessible within your PATH with the name:
+//
 //	protoc-gen-go-grpcmock
 //
 // The 'go-grpcmock' suffix becomes part of the argument for the protocol compiler,
 // such that it can be invoked as:
+//
 //	protoc --go-grpcmock_out=. path/to/file.proto
 //
 // This generates Go service definitions for the protocol buffer defined by
 // file.proto.  With that input, the output will be written to:
+//
 //	path/to/file_grpc_mock.pb.go
 package main
 

--- a/internal/framework/testify.go
+++ b/internal/framework/testify.go
@@ -87,12 +87,9 @@ func (tm *testifyMocker) generateService(g *protogen.GeneratedFile, service *pro
 	}
 }
 
-func (tm *testifyMocker) generateStruct(g *protogen.GeneratedFile, typeName string, fields ...string) {
+func (tm *testifyMocker) generateStruct(g *protogen.GeneratedFile, typeName string) {
 	g.P("type ", unexport(typeName), " struct {")
 	g.P(g.QualifiedGoIdent(testifyMockPackage.Ident("Mock")))
-	for _, field := range fields {
-		g.P(field)
-	}
 	g.P("}")
 	g.P()
 }


### PR DESCRIPTION
Always use the `latest` version of [golangci-lint](https://github.com/golangci/golangci-lint) for linting in the CI-Pipeline.